### PR TITLE
Handle blank lines in resolv.conf

### DIFF
--- a/gantry/gantry.py
+++ b/gantry/gantry.py
@@ -196,7 +196,7 @@ def _parse_resolv_conf(contents):
     resolvers = []
     for line in contents.splitlines():
         fields = line.split()
-        if fields[0] == 'nameserver' and len(fields) == 2:
+        if len(fields) == 2 and fields[0] == 'nameserver':
             resolvers.append(fields[1])
     return resolvers
 

--- a/test/unit/test_gantry.py
+++ b/test/unit/test_gantry.py
@@ -209,6 +209,7 @@ def test_start_container(resolv_mock, popen_mock):
 RESOLV_CONF_MOCK = (
     ("nameserver invalid line", []),
     ("""# a comment
+        
 domain foo
 search foo bar
 nameserver 8.8.8.8


### PR DESCRIPTION
If a resolv.conf had empty lines it would throw an exception.  Lets not
do that.
