### PR TITLE
setup: bump docker-py version to 0.1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 from gantry import __version__
 
 requirements = ['argh==0.23.2',
-                'docker-py==0.0.5']
+                'docker-py==0.1.5']
 
 HERE = os.path.dirname(__file__)
 try:


### PR DESCRIPTION
This allows gantry to manage Docker versions greater than 0.5, where a UNIX
socket is preferred over an HTTP socket.
